### PR TITLE
Fix getitemlink in injured-mouboo

### DIFF
--- a/world/map/npc/012-1/injured-mouboo.txt
+++ b/world/map/npc/012-1/injured-mouboo.txt
@@ -97,6 +97,7 @@ L_pickup_alive:
 L_give:
     set @items_nr, 12;
     setarray @items$, "CactusDrink", "CactusPotion", "ChocolateBar", "Milk", "OrangeCupcake", "RedApple", "Beer", "BottleOfWater", "TinyHealingPotion", "SmallHealingPotion", "MediumHealingPotion", "LargeHealingPotion";
+	setarray @itemnames$, "Cactus Drink", "Cactus Potion", "Chocolate Bar", "Milk", "Orange Cupcake", "Red Apple", "Beer", "Bottle of Water", "Tiny Healing Potion", "Small Healing Potion", "Medium Healing Potion", "Large Healing Potion";
     setarray @itemeat, 0,   0,   1,   0,   1,   1,   0,   1,   0,   0,   0,   0;
 
     setarray @menuItems$, "", "", "", "", "", "", "", "", "", "", "", "", "";
@@ -113,8 +114,7 @@ L_nloop:
     if (countitem(@k$) == 0)
         goto L_nloop_skip;
 
-    set @name$, getitemlink(@k$);
-    set @menuItems$[@ct], @name$;
+    set @menuItems$[@ct], @itemnames$[@n];
     set @menuNames$[@ct], @k$;
     set @choice_eat[@ct], @itemeat[@n];
     set @ct, @ct + 1;


### PR DESCRIPTION
I apply the same update https://github.com/themanaworld/tmwa-server-data/commit/dbee3775ca8cb0058e2fd06de93037887f71f0a4 for injured-mouboo
I tested with cactus drink and chocolate bar